### PR TITLE
Switch links over to jmespath.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ JMESPath.search('foo.bar', { abc: "mno" })
 #=> nil
 ```
 
-**[See the JMESPath specification for a full list of supported search expressions.](http://jmespath.readthedocs.org/en/latest/specification.html#examples)**
+**[See the JMESPath specification for a full list of supported search expressions.](http://jmespath.org/specification.html)**
 
 ## Indifferent Access
 
@@ -76,8 +76,8 @@ end
 
 * [Release Notes](https://github.com/trevorrowe/jmespath.rb/releases)
 * [License](http://www.apache.org/licenses/LICENSE-2.0)
-* [JMESPath Examples](http://jmespath.readthedocs.org/en/latest/specification.html#examples)
-* [JMESPath Specification](http://jmespath.readthedocs.org/en/latest/specification.html)
+* [JMESPath Tutorial](http://jmespath.org/tutorial.html)
+* [JMESPath Specification](http://jmespath.org/specification.html)
 
 ## License
 


### PR DESCRIPTION
The readthedocs links are for the python implementation of
jmespath, and now that there's a jmespath.org, I'm eventually
going to remove the readthedocslink for the specification and just
link to jmespath.org/specification.html.  There's already a
deprecation warning on the readthedocs link.

I also added a link to the jmespath tutorial. The previous link
to JMESPath examples was linking to the first examples in the spec,
which was just the examples for the first section, identifiers.