### PR TITLE
Replace multi_json with standard library json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ branches:
 rvm:
 - 1.9.3
 - 2.0.0
-- 2.1.2
+- 2.1
+- 2.2
 - jruby
 
 gemfile:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ An implementation of [JMESPath](https://github.com/boto/jmespath) for Ruby. This
 
 ## Installation
 
-The jmespath gem is written in pure Ruby and has a single dependency on `multi_json`.
-
 ```
 $ gem install jmespath
 ```

--- a/bin/jmespath.rb
+++ b/bin/jmespath.rb
@@ -4,9 +4,9 @@ root = File.dirname(File.dirname(__FILE__))
 $:.unshift(File.join(root, 'lib'))
 
 require 'jmespath'
-require 'multi_json'
+require 'json'
 
 expression = ARGV[0]
-json = MultiJson.load(STDIN.read)
+json = JSON.load(STDIN.read)
 
-$stdout.puts(MultiJson.dump(JMESPath.search(expression, json)))
+$stdout.puts(JSON.dump(JMESPath.search(expression, json)))

--- a/jmespath.gemspec
+++ b/jmespath.gemspec
@@ -9,5 +9,5 @@ Gem::Specification.new do |spec|
   spec.license       = 'Apache 2.0'
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb'] + ['LICENSE.txt']
-  spec.add_dependency('multi_json', '~> 1.0')
+  spec.add_dependency('json', '~> 1.8')
 end

--- a/lib/jmespath.rb
+++ b/lib/jmespath.rb
@@ -1,4 +1,4 @@
-require 'multi_json'
+require 'json'
 require 'pathname'
 
 module JMESPath
@@ -26,7 +26,7 @@ module JMESPath
       data = case data
         when Hash, Struct then data # check for most common case first
         when Pathname then load_json(data)
-        when IO, StringIO then MultiJson.load(data.read)
+        when IO, StringIO then JSON.load(data.read)
         else data
         end
       Runtime.new.search(expression, data)
@@ -34,7 +34,7 @@ module JMESPath
 
     # @api private
     def load_json(path)
-      MultiJson.load(File.open(path, 'r', encoding: 'UTF-8') { |f| f.read })
+      JSON.load(File.open(path, 'r', encoding: 'UTF-8') { |f| f.read })
     end
 
   end

--- a/lib/jmespath/lexer.rb
+++ b/lib/jmespath/lexer.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module JMESPath
   # @api private
   class Lexer
@@ -73,7 +75,7 @@ module JMESPath
       end
       tokens << Token.new(:eof, nil, offset)
       unless expression.size == offset
-        syntax_error('invalid expression', expression, offset) 
+        syntax_error('invalid expression', expression, offset)
       end
       tokens
     end
@@ -102,8 +104,8 @@ module JMESPath
     end
 
     def decode_json(json, expression, offset)
-      MultiJson.load(json)
-    rescue MultiJson::ParseError => e
+      JSON.load(json)
+    rescue JSON::ParserError => e
       syntax_error(e.message, expression, offset)
     end
 

--- a/lib/jmespath/tree_interpreter.rb
+++ b/lib/jmespath/tree_interpreter.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module JMESPath
   # @api private
   class TreeInterpreter
@@ -319,7 +321,7 @@ module JMESPath
     def function_to_string(*args)
       if args.count == 1
         value = args.first
-        String === value ? value : MultiJson.dump(value)
+        String === value ? value : JSON.dump(value)
       else
         raise Errors::InvalidArityError, "function to_string() expects one argument"
       end


### PR DESCRIPTION
As on of the authors of `multi_json`, I no longer use it in my own projects and no longer recommend its use to others, now that the `json` gem is part of the Ruby standard library. I have replaced the `multi_json` dependency with a `json` gem dependency, despite the fact that this is not strictly necessary, just to ensure that users of older versions of Ruby, which ship with an older version of `json` are using the latest gem version instead. This dependency could be removed.

I have also added Ruby 2.2 to the Travis CI matrix for testing.